### PR TITLE
add foreman gem as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source 'http://rubygems.org'
 gem 'sinatra', '1.2.6'
 gem 'thin', '1.2.7'
 gem 'maruku', '0.6.0'
+
+group :development do
+	gem 'foreman', '0.39.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,9 @@ GEM
   specs:
     daemons (1.1.3)
     eventmachine (0.12.10)
+    foreman (0.39.0)
+      term-ansicolor (~> 1.0.7)
+      thor (>= 0.13.6)
     maruku (0.6.0)
       syntax (>= 1.0.0)
     rack (1.3.0)
@@ -10,16 +13,19 @@ GEM
       rack (~> 1.1)
       tilt (>= 1.2.2, < 2.0)
     syntax (1.0.0)
+    term-ansicolor (1.0.7)
     thin (1.2.7)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
+    thor (0.14.6)
     tilt (1.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  foreman (= 0.39.0)
   maruku (= 0.6.0)
   sinatra (= 1.2.6)
   thin (= 1.2.7)


### PR DESCRIPTION
Given that the README says 'bundle install && foreman start' it seems foreman should be in here as a development dependency.
